### PR TITLE
Add unit tests for MatomoRequests

### DIFF
--- a/core/src/test/java/org/matomo/java/tracking/MatomoRequestsTest.java
+++ b/core/src/test/java/org/matomo/java/tracking/MatomoRequestsTest.java
@@ -282,4 +282,16 @@ class MatomoRequestsTest {
     assertThat(request.getCrashLine()).isNull();
     assertThat(request.getCrashColumn()).isNull();
   }
+
+  @Test
+  void crashWithThrowableHavingStackTraceIncludesLocationAndLine() {
+    RuntimeException throwable = new RuntimeException("real error");
+    MatomoRequest.MatomoRequestBuilder builder = MatomoRequests.crash(throwable, "test category");
+    MatomoRequest request = builder.build();
+    assertThat(request.getCrashMessage()).isEqualTo("real error");
+    assertThat(request.getCrashType()).isEqualTo("java.lang.RuntimeException");
+    assertThat(request.getCrashCategory()).isEqualTo("test category");
+    assertThat(request.getCrashLocation()).isNotNull();
+    assertThat(request.getCrashLine()).isNotNull();
+  }
 }


### PR DESCRIPTION
Additive unit tests for `MatomoRequests` — edge cases and current behavior pinned with explicit assertions. No existing test or production code changed (append-only).

Verified green (`mvn -pl core test -Dtest=MatomoRequestsTest` → 26 tests, 0 failures). On this class the additions raise the PIT mutation kill-rate from 124 to 135/153 mutants.



---

**How this was produced**

This PR was generated with an AI-assisted pipeline built around mutation testing (PIT). The pipeline mutates the target class (flipping conditions and changing boundary/edge cases) and runs the existing tests against each mutant. Where a mutant survives (the existing tests do not catch that edge case), it writes a focused test for that case and reruns PIT to confirm the new test actually kills that specific mutant. So every added test is verified to catch a concrete edge case the suite missed before, rather than being speculative or redundant. The change is additive only (no production code modified), and the module builds green under its CI JDK.
